### PR TITLE
support dict pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@ module.exports = function deepFreeze (o) {
   Object.freeze(o);
 
   var oIsFunction = typeof o === "function";
+  var hasOwnProp = Object.prototype.hasOwnProperty;
 
   Object.getOwnPropertyNames(o).forEach(function (prop) {
-    if (o.hasOwnProperty(prop)
+    if (hasOwnProp.call(o, prop)
     && (oIsFunction ? prop !== 'caller' && prop !== 'callee' && prop !== 'arguments' : true )
     && o[prop] !== null
     && (typeof o[prop] === "object" || typeof o[prop] === "function")

--- a/test/dict.js
+++ b/test/dict.js
@@ -1,0 +1,22 @@
+var test = require('tap').test;
+var deepFreeze = require('../');
+
+test('deep freeze', function (t) {
+  "use strict";
+
+  t.plan(3);
+
+  var a = Object.create(null);
+  a.x = 1;
+
+  deepFreeze(a);
+  var msg;
+  try {
+    a.x = 2;
+  } catch (e) {
+    msg = e.message;
+  }
+  t.ok(msg);
+  t.ok(/^cannot assign to read only property/i.test(msg));
+  t.equals(a.x, 1);
+});


### PR DESCRIPTION
I'd like to freeze dicts but they have no prototype:

```
var dict = Object.create(null);
```

We can borrow a method instead. This has been pending for ages in original deep-freeze: https://github.com/substack/deep-freeze/pull/1.
