### PR TITLE
Add support for TypedArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = function deepFreeze (o) {
+  if ( ArrayBuffer.isView(o) && !(o instanceof DataView) )
+    return o;
+
   Object.freeze(o);
 
   var oIsFunction = typeof o === "function";
@@ -13,6 +16,6 @@ module.exports = function deepFreeze (o) {
       deepFreeze(o[prop]);
     }
   });
-  
+
   return o;
 };

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -1,0 +1,11 @@
+
+var test = require('tap').test;
+var deepFreeze = require('../');
+
+test('don't throw over typedarray', function (t) {
+    var typedArray = new Uint8Array(5);
+    
+    t.doesNotThrow( function() {
+      deepFreeze(typedArray);
+    });
+});


### PR DESCRIPTION
So I came around that error : `Cannot freeze array buffer views with elements`

This error occurs when you try to freeze a `TypedArray`. I didn't find a nice way to check if our argument is a `TypedArray`. Closest thing is `ArrayBuffer.isView()` but this will also returns true for `DataView` so I check it's not because freezing a `DataView` doesn't raise the error (oddly) .

Now the second part of this pr is that I'm also currently returning, avoiding the loop through ` Object.getOwnPropertyNames()`. This is because I assume when you use `TypedArray` you're dealing with binary data and you don't want to freeze each byte of it.

Maybe you don't want to do that assumption and let the user decide using an optional param.
Or we could extend that assumption to `DataView` as well and remove the `instanceof DataView` check.

I'm more inclined to do the latter, you let me know.